### PR TITLE
Tooling to enable generic keyset pagination across sources by expressing the keyset in CQL2.

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -88,7 +88,7 @@ pub use error::Error;
 pub use fields::Fields;
 pub use filter::Filter;
 pub use item_collection::{Context, ItemCollection};
-pub use items::{GetItems, Items};
+pub use items::{GetItems, Items, JsonOps};
 pub use root::Root;
 pub use search::{GetSearch, Search};
 pub use sort::{Direction, Sortby};

--- a/crates/core/src/item.rs
+++ b/crates/core/src/item.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, FixedOffset, NaiveDateTime, Utc};
 use geojson::{Feature, Geometry, feature::Id};
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 use stac_derive::{Links, Migrate, SelfHref};
 use std::path::Path;
 use url::Url;
@@ -589,6 +589,25 @@ impl Item {
             collection: self.collection,
             properties,
         })
+    }
+
+    /// Gets a property by key looking in order from  root level then properties.
+    pub fn get_property(&self, key: &str) -> Option<Value> {
+        let j: Map<String, Value> = self.clone().try_into().expect("Could not convert item to Map");
+        let val = j
+            .get(key)
+            .or_else(
+                || j.get("properties").unwrap().get(key)
+            )
+            .or_else(
+                || j.get("properties").unwrap().get("additional_fields").unwrap().get(key)
+            )
+            .map(|v| v.clone());
+        if val.is_some() && key.ends_with("datetime") {
+            Some(json!({"timestamp": val.unwrap()}))
+        } else {
+            val
+        }
     }
 }
 


### PR DESCRIPTION
***PROOF OF CONCEPT, NOT FOR MERGING***

This exposes a next_page_cql2(Item) function on the Items struct that uses Items.sortby to generate a CQL2 Expression that can be appended to the existing CQL2 Expression that will start fetching data *beginnning* with the passed in Item.

Anticipated workflow would be that the Client would try to fetch one more row than the requested limit. If this extra row exists, it will create a next link that has the additional expression applied. If the Client began with a next link being passed to it, that would then be returned as the prev link.

I think if we architect this right in the Client that this could allow keyset based pagination for any STAC API regardless of backend.

As we look at using rustac as the primary entry point for *creating* an API for pgstac / stac-geoparquet, this lets us add in this functionality in a reusable way.

Additionally, as we chatted before, I think that moving all the logic for parsing other parameters (items, collections, datetime, ...) so that those just get mapped into CQL2 expressions. Then we can centralize the logic for either "solving" or converting into SQL expressions to CQL2-rs. Basically, I'm proposing that anything that *filters* data should get converted to CQL2.