### PR TITLE
fix: keep type on flat item

### DIFF
--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Serialize` for `Container` ([#667](https://github.com/stac-utils/rustac/pull/667))
 - More permissive datetime interval parsing ([#715](https://github.com/stac-utils/rustac/pull/715))
 - `Format` methods for providing your own object store ([#730](https://github.com/stac-utils/rustac/pull/730))
+- `type` field to **stac-geoparquet** writes ([#736](https://github.com/stac-utils/rustac/pull/736))
 
 ### Changed
 

--- a/crates/core/src/geoarrow/mod.rs
+++ b/crates/core/src/geoarrow/mod.rs
@@ -333,6 +333,13 @@ mod tests {
     }
 
     #[test]
+    fn has_type() {
+        let item: Item = crate::read("examples/simple-item.json").unwrap();
+        let table = Table::from_item_collection(vec![item]).unwrap();
+        let _ = table.schema().field_with_name("type").unwrap();
+    }
+
+    #[test]
     fn from_table() {
         let file = File::open("data/extended-item.parquet").unwrap();
         let reader = GeoParquetRecordBatchReaderBuilder::try_new(file)

--- a/crates/core/src/item.rs
+++ b/crates/core/src/item.rs
@@ -126,6 +126,9 @@ pub struct Item {
 /// use this "flat" representation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FlatItem {
+    #[serde(default = "item_type", deserialize_with = "deserialize_item_type")]
+    r#type: String,
+
     #[serde(rename = "stac_version", default = "default_stac_version")]
     version: Version,
 
@@ -579,6 +582,7 @@ impl Item {
             }
         }
         Ok(FlatItem {
+            r#type: self.r#type,
             version: STAC_VERSION,
             extensions: self.extensions,
             id: self.id,


### PR DESCRIPTION
Though the spec [recommends dropping it](https://github.com/stac-utils/stac-geoparquet/blob/a59ba7638117fc12c12784dbbe7dbd8c2d583b88/spec/stac-geoparquet-spec.md?plain=1#L23), I'd like to keep it for now:

- There's already at least one other probably-identical string field in the file (`stac_version`) so if we're trying to optimize on size we could play with metadata more to cut more columns
- Naïve geoparquet readers are more likely to be able to reconstruct valid STAC items if all the required fields are present ... without `type`, you really have to know what you're doing
- In our case, when we search **stac-geoparquet** we don't assume that we're returning valid STAC items, because the `fields` extension can be used to strip away required fields. Because of that, a direct conversion from **stac-geoparquet** to JSON will not "rehydrate" the `type` field. We _could_ add logic to `search` to do this "rehydration", but it seemed simpler and not super-high-consequence to just keep the column

cc @hrodmn