### PR TITLE
refactor!: remove `Href`

### DIFF
--- a/crates/api/src/collections.rs
+++ b/crates/api/src/collections.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use stac::{Collection, Href, Link};
+use stac::{Collection, Link};
 use stac_derive::{Links, SelfHref};
 
 /// Object containing an array of collections and an array of links.
@@ -17,7 +17,7 @@ pub struct Collections {
     pub additional_fields: Map<String, Value>,
 
     #[serde(skip)]
-    self_href: Option<Href>,
+    self_href: Option<String>,
 }
 
 impl From<Vec<Collection>> for Collections {

--- a/crates/api/src/item_collection.rs
+++ b/crates/api/src/item_collection.rs
@@ -1,7 +1,7 @@
 use crate::{Item, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
-use stac::{Href, Link};
+use stac::Link;
 use stac_derive::{Links, SelfHref};
 
 const ITEM_COLLECTION_TYPE: &str = "FeatureCollection";
@@ -95,7 +95,7 @@ pub struct ItemCollection {
     pub last: Option<Map<String, Value>>,
 
     #[serde(skip)]
-    self_href: Option<Href>,
+    self_href: Option<String>,
 }
 
 /// The search-related metadata for the [ItemCollection].

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -21,8 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Default to snappy compression for geoparquet ([#673](https://github.com/stac-utils/rustac/pull/673))
 - Ensure geoparquet->json provides valid datetime strings (UTC) ([#711](https://github.com/stac-utils/rustac/pull/711)])
-- Some `Href` method names ([#747](https://github.com/stac-utils/rustac/pull/747))
-- Use `Href` for `Asset.href` 🙈 ([#752](https://github.com/stac-utils/rustac/pull/752))
 - `href::make_absolute` is now public ([#757](https://github.com/stac-utils/rustac/pull/757))
 
 ### Fixed
@@ -32,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 - IO (moved to **stac-io**) ([#739](https://github.com/stac-utils/rustac/pull/739))
+- `Href` ([#760](https://github.com/stac-utils/rustac/pull/760))
 
 ## [0.12.0] - 2025-01-31
 

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Href, Link, Result, STAC_VERSION, Version};
+use crate::{Error, Link, Result, STAC_VERSION, Version};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use stac_derive::{Fields, Links, Migrate, SelfHref};
@@ -77,7 +77,7 @@ pub struct Catalog {
     pub additional_fields: Map<String, Value>,
 
     #[serde(skip)]
-    self_href: Option<Href>,
+    self_href: Option<String>,
 }
 
 impl Catalog {

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Asset, Assets, Bbox, Error, Href, Item, ItemAsset, Link, Links, Migrate, Result, STAC_VERSION,
+    Asset, Assets, Bbox, Error, Item, ItemAsset, Link, Links, Migrate, Result, STAC_VERSION,
     SelfHref, Version,
 };
 use chrono::{DateTime, Utc};
@@ -119,7 +119,7 @@ pub struct Collection {
     pub additional_fields: Map<String, Value>,
 
     #[serde(skip)]
-    self_href: Option<Href>,
+    self_href: Option<String>,
 }
 
 /// This object provides information about a provider.
@@ -276,8 +276,11 @@ impl Collection {
     }
 
     fn maybe_add_item_link(&mut self, item: &Item) -> Option<&Link> {
-        if let Some(href) = item.self_href().or(item.self_link().map(|link| &link.href)) {
-            self.links.push(Link::item(href.clone()));
+        if let Some(href) = item
+            .self_href()
+            .or(item.self_link().map(|link| link.href.as_str()))
+        {
+            self.links.push(Link::item(href));
             self.links.last()
         } else {
             None

--- a/crates/core/src/collection.rs
+++ b/crates/core/src/collection.rs
@@ -246,7 +246,7 @@ impl Collection {
 
     /// Creates a new collection with its extents set to match the item's.
     ///
-    /// Also, adds an `item` link if the item has a [Href] or a `item`.
+    /// Also, adds an `item` link if the item has a href or a `item`.
     ///
     /// # Examples
     ///
@@ -292,7 +292,7 @@ impl Collection {
     /// This method does a couple of things:
     ///
     /// 1. Updates this collection's extents to contain the item's spatial and temporal bounds
-    /// 2. If the item has a [Href] or a `self` link, adds a `item` link
+    /// 2. If the item has a href or a `self` link, adds a `item` link
     ///
     /// Note that collections are created, by default, with global bounds and no
     /// temporal extent, so you'll want to set those (e.g. with

--- a/crates/core/src/href.rs
+++ b/crates/core/src/href.rs
@@ -153,6 +153,24 @@ pub fn make_relative(href: &str, base: &str) -> String {
     relative
 }
 
+/// Converts this href to a Url.
+///
+/// Handles adding a `file://` prefix and making it absolute, if needed.
+pub fn make_url(href: &str) -> Result<Url> {
+    if let Ok(url) = Url::parse(href) {
+        Ok(url)
+    } else {
+        let url = if href.starts_with("/") {
+            Url::parse(&format!("file://{href}"))
+        } else {
+            let current_dir = std::env::current_dir()?;
+            let url = make_url(&format!("{}/", current_dir.to_string_lossy()))?;
+            url.join(href)
+        }?;
+        Ok(url)
+    }
+}
+
 fn normalize_path(path: &str) -> String {
     let mut parts = if path.starts_with('/') {
         Vec::new()

--- a/crates/core/src/item.rs
+++ b/crates/core/src/item.rs
@@ -1,6 +1,6 @@
 //! STAC Items.
 
-use crate::{Asset, Assets, Bbox, Error, Fields, Href, Link, Result, STAC_VERSION, Version};
+use crate::{Asset, Assets, Bbox, Error, Fields, Link, Result, STAC_VERSION, Version};
 use chrono::{DateTime, FixedOffset, NaiveDateTime, Utc};
 use geojson::{Feature, Geometry, feature::Id};
 use indexmap::IndexMap;
@@ -115,7 +115,7 @@ pub struct Item {
     pub additional_fields: Map<String, Value>,
 
     #[serde(skip)]
-    self_href: Option<Href>,
+    self_href: Option<String>,
 }
 
 /// A [FlatItem] has all of its properties at the top level.
@@ -310,11 +310,11 @@ impl Builder {
     pub fn build(self) -> Result<Item> {
         let mut item = Item::new(self.id);
         for (key, mut asset) in self.assets {
-            if let Href::String(ref s) = asset.href {
-                if self.canonicalize_paths {
-                    asset.href =
-                        Href::String(Path::new(s).canonicalize()?.to_string_lossy().into_owned());
-                }
+            if self.canonicalize_paths {
+                asset.href = Path::new(&asset.href)
+                    .canonicalize()?
+                    .to_string_lossy()
+                    .into_owned();
             }
             let _ = item.assets.insert(key, asset);
         }

--- a/crates/core/src/item_collection.rs
+++ b/crates/core/src/item_collection.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Href, Item, Link, Migrate, Result, Version};
+use crate::{Error, Item, Link, Migrate, Result, Version};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use stac_derive::{Links, SelfHref};
@@ -53,7 +53,7 @@ pub struct ItemCollection {
     pub additional_fields: Map<String, Value>,
 
     #[serde(skip)]
-    self_href: Option<Href>,
+    self_href: Option<String>,
 }
 
 impl From<Vec<Item>> for ItemCollection {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -142,7 +142,7 @@ pub use fields::Fields;
 pub use geojson::Geometry;
 #[cfg(feature = "geoparquet")]
 pub use geoparquet::{FromGeoparquet, IntoGeoparquet};
-pub use href::{Href, SelfHref};
+pub use href::SelfHref;
 pub use item::{FlatItem, Item, Properties};
 pub use item_asset::ItemAsset;
 pub use item_collection::ItemCollection;

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Catalog, Collection, Error, Href, Item, ItemCollection, Link, Links, Migrate, Result, SelfHref,
+    Catalog, Collection, Error, Item, ItemCollection, Link, Links, Migrate, Result, SelfHref,
     Version,
 };
 use serde::{Deserialize, Serialize};
@@ -188,7 +188,7 @@ impl Value {
 }
 
 impl SelfHref for Value {
-    fn self_href(&self) -> Option<&Href> {
+    fn self_href(&self) -> Option<&str> {
         use Value::*;
         match self {
             Catalog(catalog) => catalog.self_href(),
@@ -198,7 +198,7 @@ impl SelfHref for Value {
         }
     }
 
-    fn self_href_mut(&mut self) -> &mut Option<Href> {
+    fn self_href_mut(&mut self) -> &mut Option<String> {
         use Value::*;
         match self {
             Catalog(catalog) => catalog.self_href_mut(),

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -8,10 +8,10 @@ pub fn self_href_derive(input: TokenStream) -> TokenStream {
     let name = input.ident;
     let expanded = quote! {
         impl ::stac::SelfHref for #name {
-            fn self_href(&self) -> Option<&::stac::Href> {
-                self.self_href.as_ref()
+            fn self_href(&self) -> Option<&str> {
+                self.self_href.as_deref()
             }
-            fn self_href_mut(&mut self) -> &mut Option<::stac::Href> {
+            fn self_href_mut(&mut self) -> &mut Option<String> {
                 &mut self.self_href
             }
         }

--- a/crates/io/src/error.rs
+++ b/crates/io/src/error.rs
@@ -1,4 +1,3 @@
-use stac::Href;
 use thiserror::Error;
 
 /// Crate-specific error enum
@@ -9,7 +8,7 @@ pub enum Error {
     #[error("error when getting href={href}: {message}")]
     Get {
         /// The href that we were trying to get.
-        href: Href,
+        href: String,
 
         /// The underling error message.
         message: String,

--- a/crates/io/src/format.rs
+++ b/crates/io/src/format.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Readable, RealizedHref, Result, Writeable};
 use bytes::Bytes;
-use stac::{Href, SelfHref};
+use stac::SelfHref;
 use std::{fmt::Display, path::Path, str::FromStr};
 
 /// The format of STAC data.
@@ -70,9 +70,9 @@ impl Format {
     /// let item: Item = Format::json().read("examples/simple-item.json").unwrap();
     /// ```
     #[allow(unused_variables)]
-    pub fn read<T: Readable + SelfHref>(&self, href: impl Into<Href>) -> Result<T> {
-        let mut href = href.into();
-        let mut value: T = match href.clone().into() {
+    pub fn read<T: Readable + SelfHref>(&self, href: impl ToString) -> Result<T> {
+        let mut href = href.to_string();
+        let mut value: T = match href.as_str().into() {
             RealizedHref::Url(url) => {
                 #[cfg(feature = "reqwest")]
                 {
@@ -87,7 +87,7 @@ impl Format {
             RealizedHref::PathBuf(path) => {
                 let path = path.canonicalize()?;
                 let value = self.from_path(&path)?;
-                href = path.as_path().into();
+                href = path.as_path().to_string_lossy().into_owned();
                 value
             }
         };

--- a/crates/io/src/json.rs
+++ b/crates/io/src/json.rs
@@ -20,7 +20,7 @@ pub trait FromJsonPath: FromJson + SelfHref {
         let mut buf = Vec::new();
         let _ = File::open(path)?.read_to_end(&mut buf)?;
         let mut value = Self::from_json_slice(&buf)?;
-        value.set_self_href(path);
+        value.set_self_href(path.to_string_lossy());
         Ok(value)
     }
 }
@@ -57,7 +57,6 @@ mod tests {
         assert!(
             item.self_href()
                 .unwrap()
-                .as_str()
                 .ends_with("examples/simple-item.json")
         );
     }

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         let tempdir = TempDir::new().unwrap();
         let item = Item::new("an-id");
         super::write(tempdir.path().join("item.json"), item).unwrap();
-        let item: Item = super::read(tempdir.path().join("item.json")).unwrap();
+        let item: Item = super::read(tempdir.path().join("item.json").to_string_lossy()).unwrap();
         assert_eq!(item.id, "an-id");
     }
 }

--- a/crates/io/src/ndjson.rs
+++ b/crates/io/src/ndjson.rs
@@ -55,7 +55,7 @@ impl FromNdjsonPath for ItemCollection {
             items.push(serde_json::from_str(&line?)?);
         }
         let mut item_collection = ItemCollection::from(items);
-        item_collection.set_self_href(path);
+        item_collection.set_self_href(path.to_string_lossy());
         Ok(item_collection)
     }
 }
@@ -129,7 +129,6 @@ mod tests {
             item_collection
                 .self_href()
                 .unwrap()
-                .as_str()
                 .ends_with("data/items.ndjson")
         );
     }

--- a/crates/io/src/read.rs
+++ b/crates/io/src/read.rs
@@ -1,5 +1,5 @@
 use crate::{Format, Readable, Result};
-use stac::{Href, SelfHref};
+use stac::SelfHref;
 
 /// Reads a STAC value from an href.
 ///
@@ -11,8 +11,8 @@ use stac::{Href, SelfHref};
 /// ```
 /// let item: stac::Item = stac_io::read("examples/simple-item.json").unwrap();
 /// ```
-pub fn read<T: SelfHref + Readable>(href: impl Into<Href>) -> Result<T> {
-    let href = href.into();
-    let format = Format::infer_from_href(href.as_str()).unwrap_or_default();
+pub fn read<T: SelfHref + Readable>(href: impl ToString) -> Result<T> {
+    let href = href.to_string();
+    let format = Format::infer_from_href(&href).unwrap_or_default();
     format.read(href)
 }

--- a/crates/io/src/realized_href.rs
+++ b/crates/io/src/realized_href.rs
@@ -1,4 +1,3 @@
-use stac::Href;
 use std::path::PathBuf;
 use url::Url;
 
@@ -12,19 +11,18 @@ pub enum RealizedHref {
     Url(Url),
 }
 
-impl From<Href> for RealizedHref {
-    fn from(href: Href) -> RealizedHref {
-        match href {
-            Href::Url(url) => {
-                if url.scheme() == "file" {
-                    url.to_file_path()
-                        .map(RealizedHref::PathBuf)
-                        .unwrap_or_else(|_| RealizedHref::Url(url))
-                } else {
-                    RealizedHref::Url(url)
-                }
+impl From<&str> for RealizedHref {
+    fn from(s: &str) -> RealizedHref {
+        if let Ok(url) = Url::parse(s) {
+            if url.scheme() == "file" {
+                url.to_file_path()
+                    .map(RealizedHref::PathBuf)
+                    .unwrap_or_else(|_| RealizedHref::Url(url))
+            } else {
+                RealizedHref::Url(url)
             }
-            Href::String(s) => RealizedHref::PathBuf(PathBuf::from(s)),
+        } else {
+            RealizedHref::PathBuf(PathBuf::from(s))
         }
     }
 }

--- a/crates/io/src/store.rs
+++ b/crates/io/src/store.rs
@@ -17,7 +17,7 @@ pub fn parse_href_opts<I, K, V>(href: impl Into<Href>, options: I) -> Result<(St
 where
     I: IntoIterator<Item = (K, V)>,
     K: AsRef<str>,
-    V: Into<String>,
+    V: ToString,
 {
     let mut url = match href.into() {
         Href::Url(url) => url,

--- a/crates/pgstac/src/lib.rs
+++ b/crates/pgstac/src/lib.rs
@@ -330,7 +330,7 @@ pub(crate) mod tests {
     use geojson::{Geometry, Value};
     use rstest::{fixture, rstest};
     use serde_json::{Map, json};
-    use stac::{Collection, Href, Item};
+    use stac::{Collection, Item};
     use stac_api::{Fields, Filter, Search, Sortby};
     use std::{
         ops::Deref,
@@ -906,8 +906,7 @@ pub(crate) mod tests {
         search.items.limit = Some(1);
         let page = client.search(search.clone()).await.unwrap();
         if client.pgstac_version().await.unwrap().starts_with("0.9") {
-            let next_link = page.links.iter().find(|link| link.rel == "next").unwrap();
-            assert!(matches!(next_link.href, Href::Url(_)));
+            let _ = page.links.iter().find(|link| link.rel == "next").unwrap();
         }
     }
 


### PR DESCRIPTION
It was an abstraction we didn't need, it turns out.